### PR TITLE
HDDS-14661. Complete MPU parts-table split (1/N): gate hardening + schemaVersion stamping

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -188,6 +188,13 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
                   bucketInfo.getDefaultReplicationConfig() :
                   null, ozoneManager);
 
+      // Stamp the storage schema based on the layout version captured in
+      // preExecute (replicated in the Ratis log). Only uploads initiated
+      // after MPU_PARTS_TABLE_SPLIT is finalized use the split parts table;
+      // in-flight uploads keep schemaVersion 0 and the legacy inline path.
+      byte schemaVersion = getOmRequest().getLayoutVersion().getVersion()
+          >= OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion()
+          ? (byte) 1 : (byte) 0;
       multipartKeyInfo = new OmMultipartKeyInfo.Builder()
           .setUploadID(keyArgs.getMultipartUploadID())
           .setCreationTime(keyArgs.getModificationTime())
@@ -195,6 +202,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
               replicationConfig)
           .setObjectID(objectID)
           .setUpdateID(transactionLogIndex)
+          .setSchemaVersion(schemaVersion)
           .build();
 
       omKeyInfo = new OmKeyInfo.Builder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.s3.multipart.S3InitiateMultipartUploadResponseWithFSO;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartInfoInitiateRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartInfoInitiateResponse;
@@ -161,6 +162,13 @@ public class S3InitiateMultipartUploadRequestWithFSO
                   bucketInfo.getDefaultReplicationConfig() :
                   null, ozoneManager);
 
+      // Stamp the storage schema based on the layout version captured in
+      // preExecute (replicated in the Ratis log). Only uploads initiated
+      // after MPU_PARTS_TABLE_SPLIT is finalized use the split parts table;
+      // in-flight uploads keep schemaVersion 0 and the legacy inline path.
+      byte schemaVersion = getOmRequest().getLayoutVersion().getVersion()
+          >= OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion()
+          ? (byte) 1 : (byte) 0;
       multipartKeyInfo = new OmMultipartKeyInfo.Builder()
           .setUploadID(keyArgs.getMultipartUploadID())
           .setCreationTime(keyArgs.getModificationTime())
@@ -168,6 +176,7 @@ public class S3InitiateMultipartUploadRequestWithFSO
           .setObjectID(pathInfoFSO.getLeafNodeObjectId())
           .setUpdateID(transactionLogIndex)
           .setParentID(pathInfoFSO.getLastKnownParentId())
+          .setSchemaVersion(schemaVersion)
           .build();
 
       omKeyInfo = new OmKeyInfo.Builder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -165,13 +165,13 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
             OMException.ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
       }
 
-      if (!ozoneManager.getVersionManager().isAllowed(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT)
-          && multipartKeyInfo.getSchemaVersion() != 0) {
+      if (multipartKeyInfo.getSchemaVersion() != 0
+          && getOmRequest().getLayoutVersion().getVersion()
+              < OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion()) {
         throw new OMException("MPU parts-table split behavior is not allowed " +
           "before cluster finalization.",
           OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);
       }
-
 
       multipartKeyInfo = multipartKeyInfo.toBuilder()
           .setUpdateID(trxnLogIndex)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -193,8 +193,9 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
             OMException.ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
       }
 
-      if (!ozoneManager.getVersionManager().isAllowed(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT)
-          && multipartKeyInfo.getSchemaVersion() != 0) {
+      if (multipartKeyInfo.getSchemaVersion() != 0
+          && getOmRequest().getLayoutVersion().getVersion()
+              < OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion()) {
         throw new OMException("MPU parts-table split behavior is not allowed " +
           "before cluster finalization for commit part request.",
           OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -148,25 +148,6 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       multipartKeyInfo = omMetadataManager.getMultipartInfoTable()
           .get(multipartKey);
 
-      if (multipartKeyInfo == null) {
-        // This can occur when user started uploading part by the time commit
-        // of that part happens, in between the user might have requested
-        // abort multipart upload. If we just throw exception, then the data
-        // will not be garbage collected, so move this part to delete table
-        // and throw error
-        // Move this part to delete table.
-        throw new OMException("No such Multipart upload is with specified " +
-            "uploadId " + uploadID,
-            OMException.ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
-      }
-
-      if (!ozoneManager.getVersionManager().isAllowed(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT)
-          && multipartKeyInfo.getSchemaVersion() != 0) {
-        throw new OMException("MPU parts-table split behavior is not allowed " +
-          "before cluster finalization for commit part request.",
-          OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);
-      }
-
       openKey = getOpenKey(volumeName, bucketName, keyName, omMetadataManager,
               clientID);
 
@@ -199,6 +180,25 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
 
       int partNumber = keyArgs.getMultipartNumber();
       partName = getPartName(ozoneKey, uploadID, partNumber);
+
+      if (multipartKeyInfo == null) {
+        // This can occur when user started uploading part by the time commit
+        // of that part happens, in between the user might have requested
+        // abort multipart upload. If we just throw exception, then the data
+        // will not be garbage collected, so move this part to delete table
+        // and throw error
+        // Move this part to delete table.
+        throw new OMException("No such Multipart upload is with specified " +
+            "uploadId " + uploadID,
+            OMException.ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
+      }
+
+      if (!ozoneManager.getVersionManager().isAllowed(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT)
+          && multipartKeyInfo.getSchemaVersion() != 0) {
+        throw new OMException("MPU parts-table split behavior is not allowed " +
+          "before cluster finalization for commit part request.",
+          OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);
+      }
 
       oldPartKeyInfo = multipartKeyInfo.getPartKeyInfo(partNumber);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -269,10 +269,11 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
             OMException.ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
       }
 
-      if (!ozoneManager.getVersionManager().isAllowed(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT)
-          && multipartKeyInfo.getSchemaVersion() != 0) {
+      if (multipartKeyInfo.getSchemaVersion() != 0
+          && getOmRequest().getLayoutVersion().getVersion()
+              < OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion()) {
         throw new OMException("MPU parts-table split behavior is not allowed " +
-          "before cluster finalization for commit part request.",
+          "before cluster finalization for complete multipart upload request.",
           OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);
       }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.junit.jupiter.api.Test;
@@ -111,6 +113,57 @@ public class TestS3InitiateMultipartUploadRequest
         modifiedRequest.getInitiateMultiPartUploadRequest().getKeyArgs()
             .getModificationTime(), openMPUKeyInfo.getCreationTime());
 
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheStampsSchemaVersionZeroBeforeFinalization()
+      throws Exception {
+    // The default harness layout version is 0 (pre-finalization), so a newly
+    // initiated upload must use the legacy inline schema (version 0).
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+
+    OMRequest modifiedRequest =
+        doPreExecuteInitiateMPU(volumeName, bucketName, keyName);
+    getS3InitiateMultipartUploadReq(modifiedRequest)
+        .validateAndUpdateCache(ozoneManager, 100L);
+
+    String multipartKey = getMultipartKey(volumeName, bucketName, keyName,
+        modifiedRequest.getInitiateMultiPartUploadRequest()
+            .getKeyArgs().getMultipartUploadID());
+    assertEquals(0, omMetadataManager.getMultipartInfoTable()
+        .get(multipartKey).getSchemaVersion());
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheStampsSchemaVersionOneAfterFinalization()
+      throws Exception {
+    // After MPU_PARTS_TABLE_SPLIT is finalized the stamped layout version
+    // permits the split parts table, so the upload is recorded as version 1.
+    when(ozoneManager.getVersionManager().getMetadataLayoutVersion())
+        .thenReturn(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion());
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+
+    OMRequest modifiedRequest =
+        doPreExecuteInitiateMPU(volumeName, bucketName, keyName);
+    getS3InitiateMultipartUploadReq(modifiedRequest)
+        .validateAndUpdateCache(ozoneManager, 100L);
+
+    String multipartKey = getMultipartKey(volumeName, bucketName, keyName,
+        modifiedRequest.getInitiateMultiPartUploadRequest()
+            .getKeyArgs().getMultipartUploadID());
+    assertEquals(1, omMetadataManager.getMultipartInfoTable()
+        .get(multipartKey).getSchemaVersion());
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -33,6 +34,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -198,6 +200,63 @@ public class TestS3MultipartUploadCommitPartRequest
 
     assertNull(omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
+  }
+
+  /**
+   * Regression guard for the commit-after-abort path. When the multipart
+   * upload was aborted (no multipartInfoTable entry) but the part's open key
+   * still exists, the request throws NO_SUCH_MULTIPART_UPLOAD_ERROR and the
+   * response moves the orphaned part to the deleted table for GC. The null
+   * part-key check MUST run only after the open key (omKeyInfo) is resolved;
+   * otherwise the NO_SUCH response carries a null part and
+   * S3MultipartUploadCommitPartResponse#checkAndUpdateDB NPEs when the double
+   * buffer flushes it, terminating the OM. Unit tests that only assert the
+   * response status do not exercise that flush, so this test drives the
+   * response through checkAndUpdateDB to lock the ordering.
+   */
+  @Test
+  public void testValidateAndUpdateCacheCommitAfterAbortGarbageCollectsPart()
+      throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+
+    createParentPath(volumeName, bucketName);
+
+    long clientID = Time.now();
+    // Random uploadId => no multipartInfoTable entry (upload was aborted).
+    String multipartUploadID = UUID.randomUUID().toString();
+
+    OMRequest commitMultipartRequest = doPreExecuteCommitMPU(volumeName,
+        bucketName, keyName, clientID, multipartUploadID, 1);
+
+    S3MultipartUploadCommitPartRequest s3MultipartUploadCommitPartRequest =
+        getS3MultipartUploadCommitReq(commitMultipartRequest);
+
+    // The part's open key still exists (written during the part upload,
+    // before the abort).
+    addKeyToOpenKeyTable(volumeName, bucketName, keyName, clientID);
+
+    OMClientResponse omClientResponse =
+        s3MultipartUploadCommitPartRequest.validateAndUpdateCache(ozoneManager,
+            2L);
+
+    assertSame(OzoneManagerProtocolProtos.Status.NO_SUCH_MULTIPART_UPLOAD_ERROR,
+        omClientResponse.getOMResponse().getStatus());
+
+    // Flushing the error response must not NPE, and the orphaned part must be
+    // moved to the deleted table for garbage collection.
+    BatchOperation batchOperation =
+        omMetadataManager.getStore().initBatchOperation();
+    omClientResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    assertFalse(omMetadataManager.getDeletedTable()
+            .getRangeKVs(null, 100, "").isEmpty(),
+        "orphaned part should be moved to the deleted table for GC");
   }
 
   @Test


### PR DESCRIPTION
## Summary

**Part 1 of a stacked series** completing the MPU GC optimization (epic HDDS-10611 — splitting per-part info out of `multipartInfoTable` into the dormant `multipartPartsTable`). It is based on the `HDDS-14665` branch (apache/ozone#10062) so it can be merged into that branch directly; the write-side parts will stack on this branch as their own incremental PRs.

This part is the foundation: two fixes to the upgrade gate, plus the initiate-time schema stamping the write side builds on.

## Commits

1. **HDDS-14665. Fix OM crash on commit part after an aborted upload.** The gate change moved the `multipartKeyInfo == null` check ahead of `omKeyInfo` resolution, so the `NO_SUCH_MULTIPART_UPLOAD` GC path handed a null part to `S3MultipartUploadCommitPartResponse.checkAndUpdateDB`, which dereferences it on that status and NPEs when the double buffer flushes the error response &rarr; OM terminate. Reachable by a commit-part racing an abort (the exact scenario the GC branch exists for), and independent of `schemaVersion` (it hits legacy uploads). Restores the null-check to its original position after `omKeyInfo` is resolved, and adds a flush-based regression test (status-only assertions never exercised the crash).

2. **HDDS-14665. Make the upgrade gate deterministic; fix gate message.** Reads the finalization state from the request's `preExecute`-stamped `LayoutVersion` (replicated in the Ratis log) instead of a live `OMLayoutVersionManager.isAllowed()` call inside `validateAndUpdateCache`. The live read is node-local mutable state in the replicated apply path, which the method's own javadoc cautions against ("do NOT bring external dependencies ... could cause divergence in OM DB states in HA"); the stamped value is identical on every replica and on replay, regardless of how/when finalization advances the metadata layout version. This matches the leader-side `@RequestFeatureValidator(CLUSTER_NEEDS_FINALIZATION)` pattern already used for `ERASURE_CODED_STORAGE_SUPPORT` in these same requests. Also corrects the Complete gate message (it read "commit part request") and removes a stray blank line.

3. **HDDS-14661. Stamp MPU schemaVersion at initiate from layout version.** Initiate records `schemaVersion = 1` only when the stamped layout version has finalized `MPU_PARTS_TABLE_SPLIT`, otherwise 0. The schema is decided once, at initiate, from replicated state, so an upload's schema never changes mid-flight and any upload initiated before finalization keeps the legacy inline path through commit/complete/abort even if the cluster finalizes during its lifetime. Object-store and FSO paths, with pre- and post-finalization unit tests.

## Testing

`mvn -pl hadoop-ozone/ozone-manager test` for the MPU initiate/commit/complete/abort request and response classes, object-store and FSO: **67 tests, 0 failures**, including the new commit-after-abort flush regression and the pre/post-finalization stamping tests.

## Coupling note

Commit 3 is safe to merge but must **not be finalized in production** until the v1 commit/complete/abort handling lands (next PR in this series): a `schemaVersion = 1` entry reaching the legacy inline commit path would violate `OmMultipartKeyInfo`'s `schemaVersion == 1` invariant. Pre-finalization it is dormant (stamps 0). Commits 1-2 are independently safe and directly harden #10062.

## What's next (stacked on this branch)

CommitPart v1 write &rarr; Complete v1 merge &rarr; Abort + expired-abort v1 cleanup &rarr; listParts v1 &rarr; Recon (HDDS-14666), each as its own small PR so the write side can be reviewed incrementally.
